### PR TITLE
TEST testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   workflow_dispatch:
-
+# this is a test
 jobs:
   ci:
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1


### PR DESCRIPTION
This is a test do not merge

The test was to see if creating a pull-request to a repo with a ci.yml, while that account had maxed out its github action workers (was running [this](https://github.com/emteknetnz/recipe-kitchen-sink/actions/runs/2586554221) at the time) would still queue up the workflow ci for the pull-request.  It did.